### PR TITLE
more accurate check for win obj.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -94,7 +94,7 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (win === null) {
+  if (win === null || typeof win === 'undefined') {
     createWindow()
   } else {
     win.show()


### PR DESCRIPTION
the following exception was throw.

env: 
Mac: 10.14.6
Node: v12.13.1
```
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: Cannot read property 'show' of undefined
    at App.eval (webpack:///./src/background.js?:106:9)
    at App.emit (events.js:200:13)
```

so add a more accurate check for win obj, thanks to t[his link](https://flaviocopes.com/how-to-check-undefined-property-javascript/)