### PR TITLE
Keep the new window and the main window located on the same display.

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -48,12 +48,12 @@ let _interval: any = null
 let quitting = false
 let appReady = false
 
-function registerLocalVideoProtocol () {
+function registerLocalVideoProtocol() {
   protocol.registerFileProtocol('file', (request, callback) => {
-    const pathname = decodeURI(request.url.replace('file:///', ''));
+    const pathname = decodeURI(request.url.replace('file:///', ''))
     const parts = pathname.split('?')
-    callback(parts[0]);
-  });
+    callback(parts[0])
+  })
 }
 
 // Standard scheme must be registered before the app is ready
@@ -123,6 +123,11 @@ function createWindow() {
     // Load the index.html when not in development
     win.loadURL('app://./index.html')
   }
+
+  win.on('moved', () => {
+    // Saves the current state of the main window
+    mainWindowState.saveState(win)
+  })
 
   win.on('close', async(e: any) => {
     if (win !== null) {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,4 +1,5 @@
 import { remote, ipcRenderer } from 'electron'
+import windowStateKeeper from 'electron-window-state'
 let { BrowserWindow } = remote
 
 let browser: any = null
@@ -13,7 +14,12 @@ export default {
       ipcRenderer.send('currentConversationId', conversationId)
     }
     if (!browser) {
+      // Regardless of whether the main window is on the main screen or the external screen,
+      // the new window is always displayed on the screen where the main window is located.
+      let mainWindowState = windowStateKeeper({})
       browser = new BrowserWindow({
+        x: mainWindowState.x + (mainWindowState.width - 800) / 2,
+        y: mainWindowState.y + (mainWindowState.height - 600) / 2,
         resizable: false,
         minimizable: false,
         fullscreenable: true,


### PR DESCRIPTION
On macOS, when using the Mixin app on an external screen, the new window popped up by clicking the link message is still displayed on the main screen. It is better to keep the new window and the main window located on the same display.